### PR TITLE
Fix overflow errors in audio reading

### DIFF
--- a/guitar_hero_analyzer.py
+++ b/guitar_hero_analyzer.py
@@ -87,8 +87,8 @@ while running:
         if event.type == pygame.QUIT:
             running = False
 
-    # Read audio data
-    raw_data = stream.read(CHUNK)
+    # Read audio data (ignore overflow if callbacks fall behind)
+    raw_data = stream.read(CHUNK, exception_on_overflow=False)
     data = np.frombuffer(raw_data, np.float32)
 
     # Check if there's significant sound


### PR DESCRIPTION
## Summary
- avoid PyAudio overflow exceptions by setting `exception_on_overflow=False`
- add comment to clarify overflow handling

## Testing
- `python -m py_compile guitar_hero_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_b_6879ffd9ed948330a8ad78e7915d7af3